### PR TITLE
bug fix due to new scipy versions removing scipy.random

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,8 +9,6 @@ jobs:
   # when a job name is not provided
   run-lint-test:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     name: lint
     # Name the Job
     steps:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,6 +10,8 @@ jobs:
   # when a job name is not provided
   run-lint-test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     name: lint
     # Name the Job
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,8 +13,6 @@ jobs:
   # when a job name is not provided
   run-tests:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     name: Tests
     # Name the Job
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,8 @@ jobs:
   # when a job name is not provided
   run-tests:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     name: Tests
     # Name the Job
     steps:

--- a/pyrelational/datasets/classification.py
+++ b/pyrelational/datasets/classification.py
@@ -448,11 +448,11 @@ class GaussianCloudsDataset(Dataset):
         testSize2 = trainSize2 * 10
 
         # Generate parameters of datasets
-        mean1 = scipy.random.rand(n_dim)
-        cov1 = scipy.random.rand(n_dim, n_dim) - 0.5
+        mean1 = np.random.rand(n_dim)
+        cov1 = np.random.rand(n_dim, n_dim) - 0.5
         cov1 = np.dot(cov1, cov1.transpose())
-        mean2 = scipy.random.rand(n_dim)
-        cov2 = scipy.random.rand(n_dim, n_dim) - 0.5
+        mean2 = np.random.rand(n_dim)
+        cov2 = np.random.rand(n_dim, n_dim) - 0.5
         cov2 = np.dot(cov2, cov2.transpose())
 
         # Training data generation


### PR DESCRIPTION
The new version of SciPy removed the alias scipy.random for numpy.random as mentioned [here](https://docs.scipy.org/doc/scipy/release.1.9.0.html).
This pr updates the repo to account for this.

Also addressing issue #12.