### PR TITLE
Fixing pr workflow so it works for prs from forks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,8 @@ jobs:
   # when a job name is not provided
   run-tests:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     name: Tests
     # Name the Job
     steps:


### PR DESCRIPTION
As mentioned in #12, the pr workflow doesn't work when making pre from forked repos as seen [here].(https://github.com/RelationRx/pyrelational/runs/8205172900?check_suite_focus=true)

Hopefully this should fix it.