### PR TITLE
Refactor regression informativeness

### DIFF
--- a/examples/demo/lightning_mixed_regression.py
+++ b/examples/demo/lightning_mixed_regression.py
@@ -24,7 +24,7 @@ class MixedStrategy(Strategy):
     def active_learning_step(self, num_annotate):
         self.model.train(self.l_loader, self.valid_loader)
         output = self.model(self.u_loader)
-        scores = regression_least_confidence(x=output)
+        scores = regression_least_confidence(x=output.squeeze(-1))
         ixs = torch.argsort(scores, descending=True).tolist()
         ixs = [self.u_indices[i] for i in ixs[: 10 * num_annotate]]
         subquery = torch.stack(self.data_manager.get_sample_feature_vectors(ixs))

--- a/pyrelational/informativeness/regression.py
+++ b/pyrelational/informativeness/regression.py
@@ -10,32 +10,35 @@ in PyTorch is useful for defining the different active learning strategies
 from typing import Optional, Union
 
 import torch
+from torch import Tensor
 from torch.distributions import Distribution
 
 
 def regression_greedy_score(
-    x: Optional[Union[torch.Tensor, Distribution]] = None,
-    mean: Optional[torch.Tensor] = None,
+    x: Optional[Union[Tensor, Distribution]] = None,
+    mean: Optional[Tensor] = None,
     axis: int = 0,
-) -> torch.Tensor:
+) -> Tensor:
     """
     Implements greedy scoring that returns mean score for each sample across repeats.
     Either x or mean should be provided as input.
 
     :param x: 2D pytorch tensor of repeat by scores (or scores by repeat) or pytorch Distribution
-    :param std: 1D pytorch tensor corresponding to the standard deviation of a model's predictions for each sample
+    :param mean: 1D pytorch tensor corresponding to the mean of a model's predictions for each sample
     :param axis: index of the axis along which the repeats are
     :return: 1D pytorch tensor of scores
     """
-    _, mean, _ = _check_regression_informativeness_input(x, mean=mean, axis=axis)
+    _check_regression_informativeness_input(x, mean=mean)
+    if mean is None:
+        return _compute_mean(x, axis)
     return mean
 
 
 def regression_least_confidence(
-    x: Optional[Union[torch.Tensor, Distribution]] = None,
-    std: Optional[torch.Tensor] = None,
+    x: Optional[Union[Tensor, Distribution]] = None,
+    std: Optional[Tensor] = None,
     axis: int = 0,
-) -> torch.Tensor:
+) -> Tensor:
     """
     Implements least confidence scoring of based on input x returns std score for each sample across repeats.
     Either x or std should be provided as input.
@@ -45,18 +48,20 @@ def regression_least_confidence(
     :param axis: index of the axis along which the repeats are
     :return: 1D pytorch tensor of scores
     """
-    _, _, std = _check_regression_informativeness_input(x, std=std, axis=axis)
+    _check_regression_informativeness_input(x, std=std)
+    if std is None:
+        return _compute_std(x, axis)
     return std
 
 
 def regression_expected_improvement(
-    x: Optional[Union[torch.Tensor, Distribution]] = None,
-    mean: Optional[torch.Tensor] = None,
-    std: Optional[torch.Tensor] = None,
+    x: Optional[Union[Tensor, Distribution]] = None,
+    mean: Optional[Tensor] = None,
+    std: Optional[Tensor] = None,
     max_label: float = 0.0,
     axis: int = 0,
     xi: float = 0.01,
-) -> torch.Tensor:
+) -> Tensor:
     """
     Implements expected improvement based on max_label in the currently available data
     (`reference <https://doi.org/10.1023/A:1008306431147>`__).
@@ -71,10 +76,12 @@ def regression_expected_improvement(
     :param xi: 2D pytorch tensor or pytorch Distribution
     :return: 1D pytorch tensor of scores
     """
-    x, mean, std = _check_regression_informativeness_input(x, mean, std, axis=axis)
-    if isinstance(x, torch.Tensor):
+    _check_regression_informativeness_input(x, mean, std)
+    if isinstance(x, Tensor):
         return torch.relu(x - max_label).mean(axis).flatten()
     else:
+        mean = _compute_mean(x, axis) if mean is None else mean
+        std = _compute_std(x, axis) if std is None else std
         Z = torch.relu(std) * (mean - max_label - xi)
         N = torch.distributions.Normal(0, 1)
         cdf, pdf = N.cdf(Z), torch.exp(N.log_prob(Z))
@@ -82,12 +89,12 @@ def regression_expected_improvement(
 
 
 def regression_upper_confidence_bound(
-    x: Optional[Union[torch.Tensor, Distribution]] = None,
-    mean: Optional[torch.Tensor] = None,
-    std: Optional[torch.Tensor] = None,
+    x: Optional[Union[Tensor, Distribution]] = None,
+    mean: Optional[Tensor] = None,
+    std: Optional[Tensor] = None,
     kappa: float = 1,
     axis: int = 0,
-) -> torch.Tensor:
+) -> Tensor:
     """
     Implements Upper Confidence Bound (UCB) scoring (`reference <https://doi.org/10.1023/A:1013689704352>`__)
     Either x or mean and std should be provided as input.
@@ -99,12 +106,15 @@ def regression_upper_confidence_bound(
     :param axis: index of the axis along which the repeats are
     :return: 1D pytorch tensor of scores
     """
-
-    _, mean, std = _check_regression_informativeness_input(x, mean, std, axis=axis)
+    _check_regression_informativeness_input(x, mean, std)
+    if mean is None:
+        mean = _compute_mean(x, axis)
+    if std is None:
+        std = _compute_std(x, axis)
     return mean + kappa * std
 
 
-def regression_thompson_sampling(x: torch.Tensor, axis: int = 0) -> torch.Tensor:
+def regression_thompson_sampling(x: Tensor, axis: int = 0) -> Tensor:
     """
     Implements thompson sampling scoring (`reference <https://doi.org/10.1561/2200000070>`__).
 
@@ -112,13 +122,13 @@ def regression_thompson_sampling(x: torch.Tensor, axis: int = 0) -> torch.Tensor
     :param axis: index of the axis along which the repeats are
     :return: 1D pytorch tensor of scores
     """
-    x, _, _ = _check_regression_informativeness_input(x, axis=axis)
+    assert isinstance(x, Tensor), f"x input should be a torch Tensor, got {type(x)} instead."
     other_axis = (axis - 1) % 2
     idx = torch.randint(high=x.size(axis), size=(x.size(other_axis), 1))
     return x.gather(axis, idx).flatten()
 
 
-def regression_bald(x: torch.Tensor, axis: int = 0) -> torch.Tensor:
+def regression_bald(x: Tensor, axis: int = 0) -> Tensor:
     """
     Implementation of Bayesian Active Learning by Disagreement (BALD) for regression task
     (`reference <https://arxiv.org/pdf/1112.5745.pdf>`__)
@@ -127,36 +137,64 @@ def regression_bald(x: torch.Tensor, axis: int = 0) -> torch.Tensor:
     :param axis: index of the axis along which the repeats are
     :return: 1D pytorch tensor of scores
     """
-    x, _, _ = _check_regression_informativeness_input(x, axis=axis)
+    assert isinstance(x, Tensor), f"x input should be a torch Tensor, got {type(x)} instead."
     x_mean = x.mean(axis, keepdim=True)
     x = (x - x_mean) ** 2
     return torch.log(1 + x.mean(axis)) / torch.tensor(2.0)
 
 
-def _check_regression_informativeness_input(x=None, mean=None, std=None, axis=0):
+def _check_regression_informativeness_input(
+    x: Optional[Union[Tensor, Distribution]] = None,
+    mean: Optional[Tensor] = None,
+    std: Optional[Tensor] = None,
+) -> None:
+    """
+    Checks input to regression informativeness functions.
+
+    :param x: predicted tensor or distribution
+    :param mean: predicted mean
+    :param std: predicted standard deviation
+    """
     if x is None and mean is None and std is None:
         raise ValueError("Not all of x, mean, and std can be None.")
 
-    if isinstance(x, torch.Tensor):
-        x = x.squeeze()
+    if isinstance(x, Tensor):
         assert x.ndim == 2, "x input should be a 2D tensor"
-        return x, x.mean(axis), x.std(axis)
 
-    if isinstance(mean, torch.Tensor) and isinstance(std, torch.Tensor):
-        mean, std = mean.squeeze(), std.squeeze()
+    if isinstance(mean, Tensor):
         assert mean.ndim == 1, "mean input should be a 1D tensor"
-        assert std.ndim == 1, "std input should be a 1D tensor"
-        return None, mean, std
-    elif isinstance(mean, torch.Tensor):
-        mean = mean.squeeze()
-        assert mean.ndim == 1, "mean input should be a 1D tensor"
-        return None, mean, None
-    elif isinstance(std, torch.Tensor):
-        std = std.squeeze()
-        assert std.ndim == 1, "std input should be a 1D tensor"
-        return None, None, std
 
-    if isinstance(x, Distribution):
-        mean, std = x.mean.squeeze(), x.stddev.squeeze()
-        assert mean.ndim == 1, "distribution input should be 1D"
-        return None, mean, std
+    if isinstance(std, Tensor):
+        assert std.ndim == 1, "std input should be a 1D tensor"
+
+
+def _compute_mean(x: Union[Distribution, Tensor], axis: int = 0) -> Tensor:
+    """
+    Compute mean of input.
+
+    :param x: tensor or distribution
+    :param axis: axis on which to take the mean (used when x is a Tensor)
+    :return: mean vector
+    """
+    if isinstance(x, Tensor):
+        return x.mean(axis)
+    elif isinstance(x, Distribution):
+        return x.mean
+    else:
+        raise TypeError(f"Expected torch Tensor or Distribution, got {type(x)} instead.")
+
+
+def _compute_std(x: Union[Distribution, Tensor], axis: int = 0) -> Tensor:
+    """
+    Compute standard deviation of input.
+
+    :param x: tensor or distribution
+    :param axis: axis on which to take the standard deviation (used when x is a Tensor)
+    :return: std vector
+    """
+    if isinstance(x, Tensor):
+        return x.std(axis)
+    elif isinstance(x, Distribution):
+        return x.stddev
+    else:
+        raise TypeError(f"Expected torch Tensor or Distribution, got {type(x)} instead.")

--- a/pyrelational/strategies/regression/abstract_regression_strategy.py
+++ b/pyrelational/strategies/regression/abstract_regression_strategy.py
@@ -18,6 +18,6 @@ class RegressionStrategy(Strategy, ABC):
 
     def __call__(self, num_annotate: int, data_manager: DataManager, model: ModelManager) -> List[int]:
         output = self.train_and_infer(data_manager=data_manager, model=model)
-        scores = self.scoring_fn(x=output)
+        scores = self.scoring_fn(x=output.squeeze(-1))
         ixs = torch.argsort(scores, descending=True).tolist()
         return [data_manager.u_indices[i] for i in ixs[:num_annotate]]

--- a/pyrelational/strategies/regression/bald_strategy.py
+++ b/pyrelational/strategies/regression/bald_strategy.py
@@ -35,7 +35,7 @@ class SoftBALDStrategy(BALDStrategy):
 
     def __call__(self, num_annotate: int, data_manager: DataManager, model: ModelManager) -> List[int]:
         output = self.train_and_infer(data_manager=data_manager, model=model)
-        scores = self.scoring_fn(x=output) / self.T
+        scores = self.scoring_fn(x=output.squeeze(-1)) / self.T
         scores = torch.softmax(scores, -1).numpy()
         num_annotate = min(num_annotate, len(data_manager.u_indices))
         return np.random.choice(data_manager.u_indices, size=num_annotate, replace=False, p=scores).tolist()

--- a/pyrelational/strategies/regression/expected_improvement_strategy.py
+++ b/pyrelational/strategies/regression/expected_improvement_strategy.py
@@ -18,6 +18,6 @@ class ExpectedImprovementStrategy(Strategy):
     def __call__(self, num_annotate: int, data_manager: DataManager, model: ModelManager) -> List[int]:
         output = self.train_and_infer(data_manager=data_manager, model=model)
         max_label = max(data_manager.get_sample_labels(data_manager.l_indices))
-        uncertainty = regression_expected_improvement(x=output, max_label=max_label)
+        uncertainty = regression_expected_improvement(x=output.squeeze(-1), max_label=max_label)
         ixs = torch.argsort(uncertainty, descending=True).tolist()
         return [data_manager.u_indices[i] for i in ixs[:num_annotate]]

--- a/pyrelational/strategies/regression/upper_confidence_bound_strategy.py
+++ b/pyrelational/strategies/regression/upper_confidence_bound_strategy.py
@@ -18,6 +18,6 @@ class UpperConfidenceBoundStrategy(Strategy):
 
     def __call__(self, num_annotate: int, data_manager: DataManager, model: ModelManager) -> List[int]:
         output = self.train_and_infer(data_manager=data_manager, model=model)
-        uncertainty = regression_upper_confidence_bound(x=output, kappa=self.kappa)
+        uncertainty = regression_upper_confidence_bound(x=output.squeeze(-1), kappa=self.kappa)
         ixs = torch.argsort(uncertainty, descending=True).tolist()
         return [data_manager.u_indices[i] for i in ixs[:num_annotate]]

--- a/tests/informativeness/test_informativeness_scores.py
+++ b/tests/informativeness/test_informativeness_scores.py
@@ -165,8 +165,7 @@ class TestInformativenessScorer(TestCase):
     def test_regression_input_check_with_distribution_input(self) -> None:
         """Check that the check returns no x tensor and correct shapes."""
         a = torch.distributions.Normal(torch.randn(10), torch.abs(torch.randn(10)))
-        x, m, s = runc._check_regression_informativeness_input(a)
-        self.assertIsNone(x)
+        m, s = runc._compute_mean(a), runc._compute_std(a)
         self.assertEqual(m.numel(), 10)
         self.assertEqual(s.numel(), 10)
 
@@ -177,23 +176,14 @@ class TestInformativenessScorer(TestCase):
             runc._check_regression_informativeness_input(a)
             self.assertEqual(str(err.value), "distribution input should be 1D")
 
-    def test_regression_input_check_with_tensor_input(self) -> None:
+    def test_mean_std_computation(self) -> None:
         """Check output of input check when provided with a 3D tensor."""
-        a = torch.randn(25, 100, 1)
-        x, m, s = runc._check_regression_informativeness_input(a)
-        self.assertEqual(x.ndim, 2)
+        a = torch.randn(25, 100)
+        m, s = runc._compute_mean(a), runc._compute_std(a)
         self.assertEqual(m.ndim, 1)
         self.assertEqual(s.ndim, 1)
         self.assertEqual(m.numel(), 100)
         self.assertEqual(s.numel(), 100)
-
-    def test_regression_input_check_with_mean_std_input(self) -> None:
-        """Check output of input check"""
-        mean, std = torch.randn(10), torch.abs(torch.randn(10))
-        x, m, s = runc._check_regression_informativeness_input(mean=mean, std=std)
-        self.assertIsNone(x)
-        self.assertEqual(m.numel(), mean.numel())
-        self.assertEqual(s.numel(), mean.numel())
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## What is the goal of this PR?

Refactor regression informativeness scoring such that typing become clearer (preparing for mypy incoming)

## What are the changes implemented in this PR?

_check_informativeness_input function now only checks shape of inputs. Mean and std computing are now moved to a separate function.

Of note, there was a squeeze operation within this function that is a bit risky, ideally the function shouldn't perform these operationa ad-hoc. The user should provide correctly shaped input by that point. As such the .squeeze operation was moved to the strategies instead.

Also, it might worth considering removing the shape constraints enforced by _check_informativeness_input. While it make sense in most cases whereby a single output is expected (single-class or single-scalar problem), the informativeness function in and of themselves should be applicable to more outputs (not sure how this would be handled for multiclass problems though). To be discussed.