### PR TITLE
Change regression_greedy_score name to regression_mean_prediction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
     -   id: flake8
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/docs/source/notes/using_your_own_strategy.rst
+++ b/docs/source/notes/using_your_own_strategy.rst
@@ -61,7 +61,7 @@ random from the remaining queryable set.
 
     import torch
     import numpy as np
-    from pyrelational.informativeness import regression_greedy_score
+    from pyrelational.informativeness import regression_mean_prediction
     from pyrelational.strategies.generic_al_strategy import Strategy
 
 
@@ -78,7 +78,7 @@ random from the remaining queryable set.
             assert 0 <= eps <= 1, "epsilon should be a float between 0 and 1"
             self.model.train(self.l_loader, self.valid_loader)
             output = self.model(self.u_loader)
-            scores = regression_greedy_score(x=output)
+            scores = regression_mean_prediction(x=output)
             ixs = torch.argsort(scores, descending=True).tolist()
             greedy_annotate = int((1-eps)*num_annotate)
             ixs = [self.u_indices[i] for i in ixs[: greedy_annotate]]

--- a/pyrelational/informativeness/regression.py
+++ b/pyrelational/informativeness/regression.py
@@ -14,13 +14,13 @@ from torch import Tensor
 from torch.distributions import Distribution
 
 
-def regression_greedy_score(
+def regression_mean_prediction(
     x: Optional[Union[Tensor, Distribution]] = None,
     mean: Optional[Tensor] = None,
     axis: int = 0,
 ) -> Tensor:
     """
-    Implements greedy scoring that returns mean score for each sample across repeats.
+    Returns mean score for each sample across repeats.
     Either x or mean should be provided as input.
 
     :param x:  pytorch tensor of repeat by scores (or scores by repeat) or pytorch Distribution

--- a/pyrelational/strategies/regression/mean_prediction_strategy.py
+++ b/pyrelational/strategies/regression/mean_prediction_strategy.py
@@ -1,14 +1,14 @@
 from torch import Tensor
 
-from pyrelational.informativeness import regression_greedy_score
+from pyrelational.informativeness import regression_mean_prediction
 from pyrelational.strategies.regression.abstract_regression_strategy import (
     RegressionStrategy,
 )
 
 
 class MeanPredictionStrategy(RegressionStrategy):
-    """Implements Greedy Strategy whereby unlabelled samples are queried based on their predicted mean value
+    """Implements Me Strategy whereby unlabelled samples are queried based on their predicted mean value
     by the model"""
 
     def scoring_function(self, predictions: Tensor) -> Tensor:
-        return regression_greedy_score(predictions)
+        return regression_mean_prediction(predictions)

--- a/pyrelational/strategies/regression/mean_prediction_strategy.py
+++ b/pyrelational/strategies/regression/mean_prediction_strategy.py
@@ -7,8 +7,8 @@ from pyrelational.strategies.regression.abstract_regression_strategy import (
 
 
 class MeanPredictionStrategy(RegressionStrategy):
-    """Implements Me Strategy whereby unlabelled samples are queried based on their predicted mean value
-    by the model"""
+    """Implements Mean Prediction Strategy whereby unlabelled samples are queried based on their predicted mean value
+    by the model. ie samples with the highest predicted mean values are queried."""
 
     def scoring_function(self, predictions: Tensor) -> Tensor:
         return regression_mean_prediction(predictions)

--- a/tests/informativeness/test_informativeness_scores.py
+++ b/tests/informativeness/test_informativeness_scores.py
@@ -69,7 +69,7 @@ class TestInformativenessScorer(TestCase):
 
     @parameterized.expand(
         [
-            ("regression_greedy_score",),
+            ("regression_mean_prediction",),
             ("regression_thompson_sampling",),
             ("regression_least_confidence",),
             ("regression_bald",),
@@ -106,7 +106,7 @@ class TestInformativenessScorer(TestCase):
 
     @parameterized.expand(
         [
-            ("regression_greedy_score",),
+            ("regression_mean_prediction",),
             ("regression_least_confidence",),
         ]
     )
@@ -132,7 +132,7 @@ class TestInformativenessScorer(TestCase):
     def test_regression_greedy_with_mean_std_input(self) -> None:
         """Check output dimension of informativeness measures supporting mean/std input."""
         mean = torch.randn(10)
-        o = runc.regression_greedy_score(mean=mean)
+        o = runc.regression_mean_prediction(mean=mean)
         self.assertEqual(o.numel(), mean.size(0))
         torch.testing.assert_close(mean, o)
 


### PR DESCRIPTION
## What is the goal of this PR?

Change the name of regression_greedy_score to regression_mean_prediction for consistency with the change from GreedyStrategy to MeanPredictionStrategy

## What are the changes implemented in this PR?

Change name from  regression_greedy_score -> regression_mean_prediction and changes to the name where it is used
