### PR TITLE
Add label attr input to data manager 

### DIFF
--- a/pyrelational/oracles/benchmark_oracle.py
+++ b/pyrelational/oracles/benchmark_oracle.py
@@ -23,5 +23,5 @@ class BenchmarkOracle(Oracle):
 
         :return: the output of the oracle (the target value already in the dataset)
         """
-        target_value = data_manager.get_sample(idx)[-1]
+        target_value = data_manager[idx][-1]
         return target_value


### PR DESCRIPTION
## What is the goal of this PR?

Address issue #48 

## What are the changes implemented in this PR?

Add label_attr input that indicates the name of the dataset attribute corresponding to the labels/values to be predicted.

Remove redundant get_sample method.