### PR TITLE
Readthedoc build fix & single-source of requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ version: 2
 updates:
   # Enable version updates for python
   - package-ecosystem: "pip"
-    # Look for a `requirements` in the `root` directory
-    directory: "/"
+    # Look for requirements files in the `requirements` directory
+    directory: "requirements/"
     # Check for updates once a week
     schedule:
       interval: "daily"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install main package
         run: |
          pip install -e .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install main package
         run: |
          pip install -e .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -18,4 +18,4 @@ sphinx:
 # Install requirements
 python:
    install:
-   - requirements: requirements.txt
+   - requirements: requirements/doc_requirements.txt

--- a/requirements/base_requirements.txt
+++ b/requirements/base_requirements.txt
@@ -1,0 +1,8 @@
+openpyxl>=3.0.9
+pandas>=1.3.0, <2.2.1
+lightning>=1.8.6, <2.3.0
+torch>=1.9.0, <2.3.0
+torchvision>=0.10.0, <0.18.0
+scikit-learn>=1.0.2, <1.2.2
+tabulate>=0.7.0, <=0.9.0
+xlrd>=2.0.1

--- a/requirements/dev_requirements.txt
+++ b/requirements/dev_requirements.txt
@@ -1,0 +1,12 @@
+black==24.2.0
+flake8==7.0.0
+flake8-bugbear==24.2.6
+mypy==1.8
+parameterized==0.9.0
+pre-commit==2.21.0
+protobuf>=3.19.0
+pyreadr>=0.4.4
+pytest==8.0.0
+pytest-cov
+setuptools>=59.5.0
+-r base_requirements.txt

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -1,0 +1,3 @@
+-r dev_requirements.txt
+sphinx
+sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,8 @@ pip install -e .
 setup_requires = ["pytest-runner"]
 tests_require = ["pytest", "pytest-cov", "mock"]
 
-install_requires = [
-    "numpy>=1.22.0",
-    "pandas>=1.3.0",
-    "lightning>=1.8.6",
-    "torch>=1.9.0",
-    "scikit-learn>=1.0.2",
-    "tabulate>=0.7.0",
-    "pyreadr>=0.4.4",
-    "xlrd>=2.0.1",
-    "openpyxl>=3.0.9",
-]
-
+with open("requirements/base_requirements.txt", "r") as req:
+    install_requires = [line.strip() for line in req if line.strip()]
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## What is the goal of this PR?

There are two goals to this PR

1. Fix the build failure for readthedocs documentation
2. Ensure there is a single source of truth for requirements version

## What are the changes implemented in this PR?

The build failure were linked to missing requirements for sphynx in the `readthedocs.yml`. This PR breaks the requirements file into three files 
- `base_requirements.txt`, containing the minimal required packages to use pyrelational
- `dev_requirements.txt`, which adds packages necessary for development such as mypy or flake8
- `doc_requirements.txt`, which adds sphinx packages

To account for the changes, the `dependabot.yml` file is updated to look in the `requirements/` folder for all requirements files. 

As the `base_requirements.txt` now contains the single source of truth for minimal environment, we use it in `setup.py` to avoid duplication of definition. This has the added benefit of providing up-to-date upper bound for packages as well.