### PR TITLE
Constrain numpy version

### DIFF
--- a/requirements/base_requirements.txt
+++ b/requirements/base_requirements.txt
@@ -1,6 +1,7 @@
 openpyxl>=3.0.9
 pandas>=1.3.0, <2.2.3
 lightning>=1.8.6, <2.3.0
+numpy<2.0.0
 requests==2.31.0
 scikit-learn>=1.0.2, <1.4.3
 tabulate>=0.7.0, <=0.9.0


### PR DESCRIPTION
## What is the goal of this PR?
Numpy 2.0.0 introduced some breaking changes. Restricting version in requirements to prevent workflow errors.
This will need to be revisited as dependencies adopt numpy 2.0.0.

## What are the changes implemented in this PR?
Restrict numpy version in requirements.
